### PR TITLE
Automatic push to docker registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,23 @@ env:
   global:
   - GO111MODULE=on
   - AWS_SDK_LOAD_CONFIG=1
+  - DOCKER_USERNAME=altemistatravis
+  - DOCKER_NS=altemista
+  - DOCKER_REPO=altemista-billing
   - secure: Ro+5WUbz5URYG+fwsMODrdAClATnsUayDuU3IdDjS8PBY0GWYaYgUmHEODkOPPT+vehR1RA72MrhKBIUaZhyQjwlXEcUhpYlSkVH955EBfmycDqcWl0gDVfc5X1E7E1oCiu4UIZrwWlY6F4fNNVlNN3GfM+MVSozYO/HJES6eadp21khzEsOvCAuU/GwywfVa4r60VdbCekK3UgyVSfmZ2B0kk1B5uhkEl/Qsjf5z2s0GvTpPF4nR6W+BEGEXu22JvhW6hldLstEYSjSMnauN8heyFdl/6z8XRy8uZUSj9KN8u+kFi27RHayC3+7ywumywfdhNosYFRTbiPNzEzKwSn9HaCD8yJf62W1b8nMLaEKlzHGJVrOapqJ73ZQ8xZj1TeWOszf2uPT5zjhFEu10aUboZgfxQhVN9/XsIpZ3tlYEOCvoSCWJ1ZJQLvtozX2NEhIVLE1Rr7POLfmZgbgh8372tugJsNlSyRRR4ImpJCWtCW7ZEYSJVQQRtEtI1oZcRTMoEz0mtCxDyQdqIyY3+vZmE/9Rq41WHyUi/HCZ5PlEn2T308wnQDv9V76CLmgHDWBmshXf5nLuHrLOvvy4du6zNBVqsun9EX9t/zuPMu8uAUiPTH8LKx/LEsI9ShzFn8AbgDfVxr1Gm8VNDzh1MjvSZQdj3IfNh+3cMkNNeI=
   - secure: AtxHNfwcZ7j0TCDFbQWoGq4tAf1aryOppUGxPe2Y9oP3tcld0WL8FHSfyVzwi3QPKdnPTji8ycv9OjecWywLZOY1BFzxpndq2nEBGSKDFRM2I8dllaQVb/JDtcYepGaWX+zT5BzM6TkTHSASfNoI0TOfctZx5oGp8WQ9WGZLQKRz+lfSYlo4e3pj5AdCC/Al4jND2YQ7PI7z5wNB4VHjUd2LFNs8c1onZ8MenvbBv6/AGzt2yfRA63m7WQnONBvgaVI8gf6MUDWlzNIsJmEC2ccdCUl4LZS+kjlK5GOHafYIN0Q1wwLgI/GnWFbLJX4rHs5H22+VcioHzAi16ly//T7YfUJ2gv5j9iZUAvXB5/ffsK7+42sL5xCstvsMeRuqFQGpXdTqYRPabRDWm6ruaq2caShyj0Q2UuBpTK03+UdYHQmaX1l16s8SQ/RgN2X4WGTBTT9PH2yBbZHgiBoxT70fAPRNksO3baZ+zDoEikjVud/YwegV8R1MQjTy4xGmTUmP5zl1LZtSwomuaku/jjTlo13o88qF3CDcodI3uXZZvvW4HKJEcqsqQvMTBqKQKLAi2RnMAGDr7f2nlZKKDSr0HDfBJO8NU6HpMokk5jw3TALidC3ArvahGU6tRY9mzhOO4s6ODeK5kGsGJJXJ09ZpLWSq9bD6vagBh/+0NS0=
+  - secure: VFtEnvjlTZXAwQhOegLMqhsAbqVERGtpXz1PVWLMXhZfqQxelKVK/abAKoHlmWLRr7tF1AIBtUEhk8oVbK00LlHyCtICgGuEPW1rYEBVm6ZKDb+r0G6SkB3SsE2ZMgykvZIzH+40rQ5wmcd6rvMNWEwr06ORSXySreJY/LoQdDaXKMVjCUYkRFESQp5ikuhRc0XWitfjBM7JywlBFnEmJre1z6645t1GBDMCgH33WgFxrO74BhnSgLITWCqPg+waPtmo3giIJD/I3Ix2ts/qaj0TuKl+dSrSFGx5Sg3t/Aonq7ITC7Z5i+d6oYkIcBLytK8bhASVoKSvD7FYh4b74nEF8Wv66w/Furp9sJagLHJVvVaXtRgSvLH5ajE5+Ha6KEuPnwOe7iom2y7QvD3+OkXZNiQIGMJQjq3YaEETmeUFs6DgaKoxwlIPyE0eLC+57PKBDE8MsxyxkusEe4NzwNIIGAc9JcDYF9olZJkAVaOaCZEmZEa+ibcW4EqUzWYuOTVFWJZujOooMA4B+exXJxWqW9JJfkmSBhjbL8BOrEQs7HCsgD2bJMG37rFbrmqGSK6crXJ9LHuOLrVL7Sj5zWnQFotmxsnl+Mzc4PNNS8pN/kmzDb0GG43f2OemujaTzGzx3Sxm7ASRMejxRIh+gnB0eh231cSOrOlA4HeNY5Y=
 before_install:
 - docker build -t altemista-billing .
-# Is now a server, docker run does not return anymore
-# requires further testing logic or auto-termination before reenabling the next line
-# - docker run -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY altemista-billing
 before_script:
 - mkdir -p $HOME/.aws
 - cp .aws/config $HOME/.aws/config
 script:
 - go test ./...
+before_deploy:
+- docker build -t $DOCKER_REPO:$TRAVIS_COMMIT .
+deploy:
+  provider: script
+  script: bash scripts/docker_push.sh
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 script:
 - go test ./...
 before_deploy:
-- docker build -t $DOCKER_REPO:$TRAVIS_COMMIT .
+- docker build -t $DOCKER_NS/$DOCKER_REPO:$TRAVIS_COMMIT .
 deploy:
   provider: script
   script: bash scripts/docker_push.sh

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker tag $DOCKER_REPO:$COMMIT $REPO:latest
+docker tag $DOCKER_REPO:$COMMIT $DOCKER_REPO:latest
 docker tag $DOCKER_REPO:$COMMIT $DOCKER_REPO:travis-$TRAVIS_BUILD_NUMBER
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 docker push $DOCKER_NS/$DOCKER_REPO

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker tag $DOCKER_REPO:$COMMIT $DOCKER_REPO:latest
-docker tag $DOCKER_REPO:$COMMIT $DOCKER_REPO:travis-$TRAVIS_BUILD_NUMBER
+docker tag $DOCKER_NS/$DOCKER_REPO:$COMMIT $DOCKER_REPO:latest
+docker tag $DOCKER_NS/$DOCKER_REPO:$COMMIT $DOCKER_REPO:travis-$TRAVIS_BUILD_NUMBER
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 docker push $DOCKER_NS/$DOCKER_REPO

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+docker tag $DOCKER_REPO:$COMMIT $REPO:latest
+docker tag $DOCKER_REPO:$COMMIT $DOCKER_REPO:travis-$TRAVIS_BUILD_NUMBER
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker push $DOCKER_NS/$DOCKER_REPO


### PR DESCRIPTION
With these changes, travis will automatically tag and push images built from `master` to the docker registry, at altemista/altemista-billing.

I've tested these commands locally, you can view the results on [our dockerhub](https://cloud.docker.com/u/altemista/repository/docker/altemista/altemista-billing)

This will adress issue #13 