### PR TITLE
renamed api flag to provider

### DIFF
--- a/cmd/argparse.go
+++ b/cmd/argparse.go
@@ -10,7 +10,7 @@ const (
 	iso8601 = "2006-01-02"
 )
 
-func parseCostAPI(s string) (costapi costs.APICall) {
+func parseCostProvider(s string) (costapi costs.APICall) {
 	costapi = costs.Default()
 	switch s {
 	case "aws":

--- a/cmd/invoice.go
+++ b/cmd/invoice.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	month  string
-	api    string
-	bucket string
+	month    string
+	provider string
+	bucket   string
 	// invoiceCmd represents the createBill command
 	invoiceCmd = &cobra.Command{
 		Use:   "invoice",
@@ -34,9 +34,9 @@ func init() {
 		log.Fatal("Unable to bind viper to flag:", err)
 	}
 
-	// api flag & config
-	invoiceCmd.Flags().StringVar(&api, "api", "aws", "Specifies the API to work with: aws, azure or onpremise")
-	if err := viper.BindPFlag("api", invoiceCmd.Flags().Lookup("api")); err != nil {
+	// provider flag & config
+	invoiceCmd.Flags().StringVar(&provider, "provider", "aws", "Specifies the API to work with: aws, azure or onpremise")
+	if err := viper.BindPFlag("provider", invoiceCmd.Flags().Lookup("provider")); err != nil {
 		log.Fatal("Unable to bind viper to flag:", err)
 	}
 
@@ -51,7 +51,7 @@ func init() {
 
 func cost() {
 	// Select appropriate API
-	costapi := parseCostAPI(viper.GetString("api"))
+	costapi := parseCostProvider(viper.GetString("provider"))
 
 	// Validate the string and parse into time.Time struct
 	parsedMonth, err := parseMonth(viper.GetString("month"))

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -38,14 +38,14 @@ func init() {
 }
 
 func handleCosts(w http.ResponseWriter, r *http.Request) {
-	target := r.URL.Query().Get("api")
+	provider := r.URL.Query().Get("provider")
 	month := r.URL.Query().Get("month")
 	bucket := r.URL.Query().Get("bucket")
 
 	// bucket is required
 	if bucket == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Parameter missing: bucket."))
+		w.Write([]byte("Required parameter missing: bucket."))
 	}
 
 	// try to parse month
@@ -57,7 +57,7 @@ func handleCosts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Select appropriate API
-	costapi := parseCostAPI(target)
+	costapi := parseCostProvider(provider)
 
 	// Execute the request
 	output, err := costapi(parsedMonth)


### PR DESCRIPTION
Renamed --api flag to --provider, and corresponding variables / functions, as discussed in #37 